### PR TITLE
Added tracking total hits

### DIFF
--- a/be/src/Infrastructure/Catalog/Foundation.Catalog/Repositories/ProductSearchRepositories/ProductSearchRepository.cs
+++ b/be/src/Infrastructure/Catalog/Foundation.Catalog/Repositories/ProductSearchRepositories/ProductSearchRepository.cs
@@ -74,7 +74,7 @@ namespace Foundation.Catalog.Repositories.ProductSearchRepositories
                 itemsPerPage = Constants.MaxItemsPerPageLimit;
             }
 
-            var response = await this.elasticClient.SearchAsync<ProductSearchModel>(s => s.From((pageIndex - 1) * itemsPerPage).Size(itemsPerPage).Query(q => query).Sort(s => orderBy.ToElasticSortList<ProductSearchModel>()));
+            var response = await this.elasticClient.SearchAsync<ProductSearchModel>(s => s.TrackTotalHits().From((pageIndex - 1) * itemsPerPage).Size(itemsPerPage).Query(q => query).Sort(s => orderBy.ToElasticSortList<ProductSearchModel>()));
 
             if (response.IsValid)
             {


### PR DESCRIPTION
Hi @dawiddworak88 

I added this solution because not all products appear in the generated excels, because the total items property was always 10 000

Before: 

![obraz](https://user-images.githubusercontent.com/93117743/216051388-91c443ca-f149-4790-9d73-7112170e06e6.png)

After:

![obraz](https://user-images.githubusercontent.com/93117743/216051549-b8414e2d-1a8f-41d8-bbc2-6d2af18b719c.png)
