### PR TITLE
Improved indexing method

### DIFF
--- a/be/src/Infrastructure/Catalog/Foundation.Catalog/Repositories/ProductIndexingRepositories/ProductIndexingRepository.cs
+++ b/be/src/Infrastructure/Catalog/Foundation.Catalog/Repositories/ProductIndexingRepositories/ProductIndexingRepository.cs
@@ -170,17 +170,20 @@ namespace Foundation.Catalog.Repositories.Products.ProductIndexingRepositories
                                                 {
                                                     JValue title = (JValue)categorySchemaObject.SelectToken($"$.definitions...anyOf[?(@.enum[0] == '{id}')].title");
 
-                                                    var value = new
+                                                    if (title is not null)
                                                     {
-                                                        Name = propertyObject["title"].Value<string>(),
-                                                        Value = new
+                                                        var value = new
                                                         {
-                                                            Id = id,
-                                                            Name = title.Value<string>()
-                                                        }
-                                                    };
+                                                            Name = propertyObject["title"].Value<string>(),
+                                                            Value = new
+                                                            {
+                                                                Id = id,
+                                                                Name = title.Value<string>()
+                                                            }
+                                                        };
 
-                                                    productAttributes.Add(key, value);
+                                                        productAttributes.Add(key, value);
+                                                    }
                                                 }
                                                 else
                                                 {


### PR DESCRIPTION
Hi @dawiddworak88,

This has been corrected in the PR:

When the scheme had definitions, but they were empty, it threw an error with the inability to index this product.