### PR TITLE
Reverted schemas duplication

### DIFF
--- a/be/src/Project/Services/Catalog/Catalog.Api/Services/Categories/CategoriesService.cs
+++ b/be/src/Project/Services/Catalog/Catalog.Api/Services/Categories/CategoriesService.cs
@@ -288,6 +288,23 @@ namespace Catalog.Api.Services.Categories
 
             await _context.CategoryImages.AddRangeAsync(images);
 
+            var schemas = new List<CategorySchema>();
+
+            foreach (var schema in model.Schemas.OrEmptyIfNull())
+            {
+                var categorySchema = new CategorySchema
+                {
+                    Schema = schema.Schema,
+                    UiSchema = schema.UiSchema,
+                    CategoryId = category.Id,
+                    Language = schema.Language
+                };
+
+                schemas.Add(categorySchema.FillCommonProperties());
+            }
+
+            await _context.CategorySchemas.AddRangeAsync(schemas);
+
             await _context.SaveChangesAsync();
 
             return Get(new GetCategoryServiceModel { Id = category.Id, Language = model.Language, OrganisationId = model.OrganisationId, Username = model.Username });

--- a/be/src/Project/Web/Seller/Seller.Web/Areas/Products/ModelBuilders/DuplicateCategoryFormModelBuilder.cs
+++ b/be/src/Project/Web/Seller/Seller.Web/Areas/Products/ModelBuilders/DuplicateCategoryFormModelBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Foundation.Extensions.ModelBuilders;
+﻿using Foundation.Extensions.ExtensionMethods;
+using Foundation.Extensions.ModelBuilders;
 using Foundation.Localization;
 using Foundation.Media.Services.MediaServices;
 using Foundation.PageContent.ComponentModels;
@@ -10,6 +11,7 @@ using Seller.Web.Areas.Shared.Repositories.Media;
 using Seller.Web.Shared.Definitions;
 using Seller.Web.Shared.ViewModels;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Seller.Web.Areas.ModelBuilders.Products
@@ -72,6 +74,19 @@ namespace Seller.Web.Areas.ModelBuilders.Products
                                 }
                             };
                         }
+                    }
+
+                    var categorySchemas = await _categoriesRepository.GetCategorySchemasAsync(componentModel.Token, componentModel.Language, componentModel.Id);
+
+                    if (categorySchemas is not null)
+                    {
+                        viewModel.Schemas = categorySchemas.Schemas.OrEmptyIfNull().Select(x => new CategorySchemaViewModel
+                        {
+                            Id = x.Id,
+                            Schema = x.Schema,
+                            UiSchema = x.UiSchema,
+                            Language = x.Language
+                        });
                     }
                 }
             }

--- a/be/src/Project/Web/Seller/Seller.Web/Areas/Products/ViewModels/CategoryFormViewModel.cs
+++ b/be/src/Project/Web/Seller/Seller.Web/Areas/Products/ViewModels/CategoryFormViewModel.cs
@@ -10,6 +10,7 @@ namespace Seller.Web.Areas.Products.ViewModels
         public string Name { get; set; }
         public Guid? ParentCategoryId { get; set; }
         public IEnumerable<FileViewModel> Files { get; set; }
+        public IEnumerable<CategorySchemaViewModel> Schemas { get; set; }
         public string Language { get; set; }
         public CategoryBaseFormViewModel CategoryBase { get; set; }
     }

--- a/be/src/Project/Web/Seller/Seller.Web/Areas/Products/ViewModels/CategorySchemaViewModel.cs
+++ b/be/src/Project/Web/Seller/Seller.Web/Areas/Products/ViewModels/CategorySchemaViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Seller.Web.Areas.Products.ViewModels
+{
+    public class CategorySchemaViewModel
+    {
+        public Guid? Id { get; set; }
+        public string Schema { get; set; }
+        public string UiSchema { get; set; }
+        public string Language { get; set; }
+    }
+}

--- a/fe/projects/Seller.Portal/src/areas/Products/components/CategoryForm/CategoryForm.js
+++ b/fe/projects/Seller.Portal/src/areas/Products/components/CategoryForm/CategoryForm.js
@@ -15,7 +15,9 @@ function CategoryForm(props) {
         id: { value: props.id ? props.id : null, error: "" },
         name: { value: props.name ? props.name : "", error: "" },
         parentCategoryId: { value: props.parentCategoryId ? props.parentCategoryId : "" },
-        files: { value: props.files ? props.files : [] }
+        files: { value: props.files ? props.files : [] },
+        schemas: { value: props.schemas ? props.schemas : null},         
+        uiSchema: { value: props.uiSchema ? JSON.parse(props.uiSchema) : null }
     };    
 
     const stateValidatorSchema = {
@@ -34,7 +36,8 @@ function CategoryForm(props) {
             id,
             name,
             parentCategoryId,
-            files   
+            files,
+            schemas: state.schemas
         };        
         
         const requestOptions = {


### PR DESCRIPTION
Hi @dawiddworak88 ,

In my opinion, it was enough to just remove the display of schemas from the /Categories endpoint and leave the rest. So I did that and restored it because the schema duplication uses completely different endings

The removal of schema display itself is noticeable in the local environment, so it should probably be okay