### PR TITLE
Change node version to 20.14-alpine

### DIFF
--- a/.github/workflows/giuru-buyer-web-cd-prod.yaml
+++ b/.github/workflows/giuru-buyer-web-cd-prod.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "20.11.1"
+          node-version: "20.14"
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps

--- a/.github/workflows/giuru-seller-web-cd-prod.yaml
+++ b/.github/workflows/giuru-seller-web-cd-prod.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "20.11.1"
+          node-version: "20.14"
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps

--- a/be/src/Project/Services/Content/Content.Api/Dockerfile
+++ b/be/src/Project/Services/Content/Content.Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add  build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev
 

--- a/be/src/Project/Services/Content/Content.Api/Dockerfile-dev-local
+++ b/be/src/Project/Services/Content/Content.Api/Dockerfile-dev-local
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add  build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev
 

--- a/fe/projects/Account/Dockerfile-ssr
+++ b/fe/projects/Account/Dockerfile-ssr
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add python3 make g++
 

--- a/fe/projects/Account/Dockerfile-ssr-local
+++ b/fe/projects/Account/Dockerfile-ssr-local
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add python3 make g++
 

--- a/fe/projects/AspNetCore/Dockerfile-ssr
+++ b/fe/projects/AspNetCore/Dockerfile-ssr
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add python3 make g++
 

--- a/fe/projects/AspNetCore/Dockerfile-ssr-local
+++ b/fe/projects/AspNetCore/Dockerfile-ssr-local
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add python3 make g++
 

--- a/fe/projects/Seller.Portal/Dockerfile-ssr
+++ b/fe/projects/Seller.Portal/Dockerfile-ssr
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add python3 make g++
 

--- a/fe/projects/Seller.Portal/Dockerfile-ssr-local
+++ b/fe/projects/Seller.Portal/Dockerfile-ssr-local
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:20.14-alpine
 
 RUN apk update && apk add python3 make g++
 


### PR DESCRIPTION
I changed the Node version to 20.14-alpine in the Account, Seller.Portal, AspNetCore, and Content.Api projects. The new version of Docker Desktop was causing issues with downloading the necessary components to run the B2B project.