### PR TITLE
Fix catalog product indexing timeouts with missing indexes

### DIFF
--- a/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/Brand.cs
+++ b/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/Brand.cs
@@ -1,9 +1,11 @@
 ﻿using Foundation.GenericRepository.Entities;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Foundation.Catalog.Infrastructure.Products.Entities
 {
+    [Index(nameof(SellerId))]
     public class Brand : Entity
     {
         [Required]

--- a/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/Product.cs
+++ b/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/Product.cs
@@ -1,11 +1,13 @@
 ﻿using Foundation.Catalog.Infrastructure.Categories.Entities;
 using Foundation.GenericRepository.Entities;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace Foundation.Catalog.Infrastructure.Products.Entities
 {
+    [Index(nameof(PrimaryProductId))]
     public class Product : Entity
     {
         public Guid? PrimaryProductId { get; set; }

--- a/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/ProductFile.cs
+++ b/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/ProductFile.cs
@@ -1,8 +1,10 @@
 ﻿using Foundation.GenericRepository.Entities;
+using Microsoft.EntityFrameworkCore;
 using System;
 
 namespace Foundation.Catalog.Infrastructure.Products.Entities
 {
+    [Index(nameof(ProductId))]
     public class ProductFile : EntityMedia
     {
         public Guid ProductId { get; set; }

--- a/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/ProductImage.cs
+++ b/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/ProductImage.cs
@@ -1,8 +1,10 @@
 ﻿using Foundation.GenericRepository.Entities;
+using Microsoft.EntityFrameworkCore;
 using System;
 
 namespace Foundation.Catalog.Infrastructure.Products.Entities
 {
+    [Index(nameof(ProductId))]
     public class ProductImage : EntityMedia
     {
         public Guid ProductId { get; set; }

--- a/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/ProductVideo.cs
+++ b/be/src/Infrastructure/Catalog/Foundation.Catalog/Infrastructure/Products/Entities/ProductVideo.cs
@@ -1,8 +1,10 @@
 ﻿using Foundation.GenericRepository.Entities;
+using Microsoft.EntityFrameworkCore;
 using System;
 
 namespace Foundation.Catalog.Infrastructure.Products.Entities
 {
+    [Index(nameof(ProductId))]
     public class ProductVideo : EntityMedia
     {
         public Guid ProductId { get; set; }

--- a/be/src/Project/Services/Catalog/Catalog.Api/Infrastructure/Migrations/20260610120000_AddProductIndexingIndexes.cs
+++ b/be/src/Project/Services/Catalog/Catalog.Api/Infrastructure/Migrations/20260610120000_AddProductIndexingIndexes.cs
@@ -1,0 +1,65 @@
+using Foundation.Catalog.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Catalog.Api.Infrastructure.Migrations
+{
+    [DbContext(typeof(CatalogContext))]
+    [Migration("20260610120000_AddProductIndexingIndexes")]
+    public partial class AddProductIndexingIndexes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductImages_ProductId",
+                table: "ProductImages",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductVideos_ProductId",
+                table: "ProductVideos",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductFiles_ProductId",
+                table: "ProductFiles",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Brands_SellerId",
+                table: "Brands",
+                column: "SellerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_PrimaryProductId",
+                table: "Products",
+                column: "PrimaryProductId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ProductImages_ProductId",
+                table: "ProductImages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProductVideos_ProductId",
+                table: "ProductVideos");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProductFiles_ProductId",
+                table: "ProductFiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Brands_SellerId",
+                table: "Brands");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Products_PrimaryProductId",
+                table: "Products");
+        }
+    }
+}

--- a/be/src/Project/Services/Catalog/Catalog.Api/Infrastructure/Migrations/CatalogContextModelSnapshot.cs
+++ b/be/src/Project/Services/Catalog/Catalog.Api/Infrastructure/Migrations/CatalogContextModelSnapshot.cs
@@ -343,6 +343,8 @@ namespace Catalog.Api.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("SellerId");
+
                     b.ToTable("Brands");
                 });
 
@@ -399,6 +401,8 @@ namespace Catalog.Api.Infrastructure.Migrations
 
                     b.HasIndex("CategoryId");
 
+                    b.HasIndex("PrimaryProductId");
+
                     b.ToTable("Products");
                 });
 
@@ -433,6 +437,8 @@ namespace Catalog.Api.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("ProductId");
+
                     b.ToTable("ProductFiles");
                 });
 
@@ -466,6 +472,8 @@ namespace Catalog.Api.Infrastructure.Migrations
                         .HasColumnType("rowversion");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ProductId");
 
                     b.ToTable("ProductImages");
                 });
@@ -542,6 +550,8 @@ namespace Catalog.Api.Infrastructure.Migrations
                         .HasColumnType("rowversion");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ProductId");
 
                     b.ToTable("ProductVideos");
                 });

--- a/be/src/Tests/Giuru.IntegrationTests/CatalogIndexingTests.cs
+++ b/be/src/Tests/Giuru.IntegrationTests/CatalogIndexingTests.cs
@@ -1,0 +1,67 @@
+using Foundation.ApiExtensions.Models.Response;
+using Foundation.GenericRepository.Definitions;
+using Foundation.GenericRepository.Paginations;
+using Giuru.IntegrationTests.Definitions;
+using Giuru.IntegrationTests.Helpers;
+using Seller.Web.Areas.Products.ApiRequestModels;
+using Seller.Web.Areas.Products.DomainModels;
+using Seller.Web.Shared.ApiRequestModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Giuru.IntegrationTests
+{
+    [Collection(nameof(ApiCollection))]
+    public class CatalogIndexingTests
+    {
+        private readonly ApiFixture _apiFixture;
+
+        public CatalogIndexingTests(ApiFixture apiFixture)
+        {
+            _apiFixture = apiFixture;
+        }
+
+        [Fact]
+        public async Task CreateProductWithMedia_IsIndexedAndBecomesVisibleInSearch()
+        {
+            var images = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+            var files = new[] { Guid.NewGuid() };
+
+            var createResult = await _apiFixture.SellerWebClient.PostAsync<SaveProductRequestModel, BaseResponseModel>(
+                ApiEndpoints.ProductsApiEndpoint,
+                new SaveProductRequestModel
+                {
+                    Name = "Indexing Media Product",
+                    Sku = "IDX_MEDIA_01",
+                    CategoryId = Products.Lamica.CategoryId,
+                    IsPublished = true,
+                    Ean = "5901234123457",
+                    Images = images.Select(id => new SaveFileRequestModel { Id = id }),
+                    Files = files.Select(id => new SaveFileRequestModel { Id = id })
+                });
+
+            Assert.NotNull(createResult);
+            Assert.NotEqual(Guid.Empty, createResult.Id);
+
+            var visible = await ProductWaitHelper.WaitForProductToBeVisibleAsync(_apiFixture, createResult.Id.Value);
+
+            Assert.True(visible, $"Product {createResult.Id} did not become visible in search within the timeout");
+
+            var getResults = await DataHelper.GetDataAsync(
+                () => _apiFixture.SellerWebClient.GetAsync<PagedResults<IEnumerable<Product>>>(
+                    $"{ApiEndpoints.GetProductsApiEndpoint}?pageIndex={Constants.DefaultPageIndex}&itemsPerPage={Constants.DefaultItemsPerPage}"),
+                x => x != null && x.Id == createResult.Id);
+
+            var product = getResults.Data.FirstOrDefault(x => x.Id == createResult.Id);
+
+            Assert.NotNull(product);
+            Assert.Equal("IDX_MEDIA_01", product.Sku);
+            Assert.NotNull(product.Images);
+            Assert.Equal(images.OrderBy(x => x), product.Images.OrderBy(x => x));
+            Assert.NotNull(product.Files);
+            Assert.Equal(files.OrderBy(x => x), product.Files.OrderBy(x => x));
+        }
+    }
+}


### PR DESCRIPTION
@dawiddworak88 indexation queries ProductImages/ProductVideos/ProductFiles with the ProductId filter for each battch 

That's why timeouts were occurring again.